### PR TITLE
Implement `api_gateway_infer_root_path` option

### DIFF
--- a/docs/adapter.md
+++ b/docs/adapter.md
@@ -9,6 +9,7 @@ handler = Mangum(
     api_gateway_base_path=None,
     custom_handlers=None,
     text_mime_types=None,
+    api_gateway_infer_root_path=False
 )
 ```
 

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -45,6 +45,7 @@ class Mangum:
         custom_handlers: Optional[List[Type[LambdaHandler]]] = None,
         text_mime_types: Optional[List[str]] = None,
         exclude_headers: Optional[List[str]] = None,
+        api_gateway_infer_root_path: bool = False,
     ) -> None:
         if lifespan not in ("auto", "on", "off"):
             raise ConfigurationError(
@@ -57,6 +58,7 @@ class Mangum:
         exclude_headers = exclude_headers or []
         self.config = LambdaConfig(
             api_gateway_base_path=api_gateway_base_path or "/",
+            api_gateway_infer_root_path=api_gateway_infer_root_path,
             text_mime_types=text_mime_types or [*DEFAULT_TEXT_MIME_TYPES],
             exclude_headers=[header.lower() for header in exclude_headers],
         )

--- a/mangum/types.py
+++ b/mangum/types.py
@@ -116,6 +116,7 @@ class Response(TypedDict):
 
 class LambdaConfig(TypedDict):
     api_gateway_base_path: str
+    api_gateway_infer_root_path: bool
     text_mime_types: List[str]
     exclude_headers: List[str]
 


### PR DESCRIPTION
The `api_gateway_infer_root_path` option instructs Mangum to infer the `root_path` ASGI scope property based on the AWS API Gateway event object. This enables applications to know what subpath they are being served from, without explicit configuration.

Relates to #147.

See [this comment](https://github.com/jordaneremieff/mangum/issues/147#issuecomment-1833920783) describing the solution.