### PR TITLE
Fix failing GitHub actions and add separate linting action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Lint
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -22,8 +22,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -U -r requirements.txt
-      - name: Run tests
+      - name: Run linters
         run: |
-          scripts/test
-      - name: Run codecov
-        run: codecov
+          scripts/lint

--- a/mangum/handlers/alb.py
+++ b/mangum/handlers/alb.py
@@ -104,7 +104,6 @@ class ALB:
 
     @property
     def scope(self) -> Scope:
-
         headers = transform_headers(self.event)
         list_headers = [list(x) for x in headers]
         # Unique headers. If there are duplicates, it will use the last defined.

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -93,7 +93,6 @@ class HTTPCycle:
             self.state is HTTPCycleState.RESPONSE
             and message["type"] == "http.response.body"
         ):
-
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
             self.buffer.write(body)

--- a/mangum/protocols/lifespan.py
+++ b/mangum/protocols/lifespan.py
@@ -98,14 +98,12 @@ class LifespanCycle:
     async def receive(self) -> Message:
         """Awaited by the application to receive ASGI `lifespan` events."""
         if self.state is LifespanCycleState.CONNECTING:
-
             # Connection established. The next event returned by the queue will be
             # `lifespan.startup` to inform the application that the connection is
             # ready to receive lfiespan messages.
             self.state = LifespanCycleState.STARTUP
 
         elif self.state is LifespanCycleState.STARTUP:
-
             # Connection shutting down. The next event returned by the queue will be
             # `lifespan.shutdown` to inform the application that the connection is now
             # closing so that it may perform cleanup.

--- a/tests/handlers/test_alb.py
+++ b/tests/handlers/test_alb.py
@@ -205,7 +205,7 @@ def test_aws_alb_scope_real(
     if scope_path == "":
         scope_path = "/"
 
-    assert type(handler.body) == bytes
+    assert type(handler.body) is bytes
     assert handler.scope == {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "aws.context": {},

--- a/tests/handlers/test_api_gateway.py
+++ b/tests/handlers/test_api_gateway.py
@@ -105,7 +105,7 @@ def test_aws_api_gateway_scope_basic():
     example_context = {}
     handler = APIGateway(example_event, example_context, {"api_gateway_base_path": "/"})
 
-    assert type(handler.body) == bytes
+    assert type(handler.body) is bytes
     assert handler.scope == {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "aws.context": {},

--- a/tests/handlers/test_custom.py
+++ b/tests/handlers/test_custom.py
@@ -52,7 +52,7 @@ class CustomHandler:
 def test_custom_handler():
     event = {"my-custom-key": 1}
     handler = CustomHandler(event, {}, {"api_gateway_base_path": "/"})
-    assert type(handler.body) == bytes
+    assert type(handler.body) is bytes
     assert handler.scope == {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "aws.context": {},

--- a/tests/handlers/test_http_gateway.py
+++ b/tests/handlers/test_http_gateway.py
@@ -199,7 +199,7 @@ def test_aws_http_gateway_scope_basic_v1():
         example_event, example_context, {"api_gateway_base_path": "/"}
     )
 
-    assert type(handler.body) == bytes
+    assert type(handler.body) is bytes
     assert handler.scope == {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "aws.context": {},
@@ -308,7 +308,7 @@ def test_aws_http_gateway_scope_basic_v2():
         example_event, example_context, {"api_gateway_base_path": "/"}
     )
 
-    assert type(handler.body) == bytes
+    assert type(handler.body) is bytes
     assert handler.scope == {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "aws.context": {},

--- a/tests/handlers/test_lambda_at_edge.py
+++ b/tests/handlers/test_lambda_at_edge.py
@@ -138,7 +138,7 @@ def test_aws_cf_lambda_at_edge_scope_basic():
         example_event, example_context, {"api_gateway_base_path": "/"}
     )
 
-    assert type(handler.body) == bytes
+    assert type(handler.body) is bytes
     assert handler.scope == {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "aws.context": {},


### PR DESCRIPTION
Fix failing GitHub actions and add separate linting action.

Fix the files that needed to be linted. 

Add separate listing workflow so that linting only runs on a single Python version because Black might format files differently for different Python versions.