### PR TITLE
Add support for lifespan state

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -76,7 +76,7 @@ class Mangum:
             if self.lifespan in ("auto", "on"):
                 lifespan_cycle = LifespanCycle(self.app, self.lifespan)
                 stack.enter_context(lifespan_cycle)
-                scope |= {"state": lifespan_cycle.lifespan_state.copy()}
+                scope.update({"state": lifespan_cycle.lifespan_state.copy()})
 
             http_cycle = HTTPCycle(scope, handler.body)
             http_response = http_cycle(self.app)

--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -1,19 +1,20 @@
 import logging
-from contextlib import ExitStack
 from itertools import chain
+from contextlib import ExitStack
 from typing import List, Optional, Type
 
-from mangum.exceptions import ConfigurationError
-from mangum.handlers import ALB, APIGateway, HTTPGateway, LambdaAtEdge
 from mangum.protocols import HTTPCycle, LifespanCycle
+from mangum.handlers import ALB, HTTPGateway, APIGateway, LambdaAtEdge
+from mangum.exceptions import ConfigurationError
 from mangum.types import (
     ASGI,
-    LambdaConfig,
-    LambdaContext,
-    LambdaEvent,
-    LambdaHandler,
     LifespanMode,
+    LambdaConfig,
+    LambdaEvent,
+    LambdaContext,
+    LambdaHandler,
 )
+
 
 logger = logging.getLogger("mangum")
 

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -3,8 +3,8 @@ import enum
 import logging
 from io import BytesIO
 
-from mangum.types import ASGI, Message, Scope, Response
 from mangum.exceptions import UnexpectedMessage
+from mangum.types import ASGI, Message, Response, Scope
 
 
 class HTTPCycleState(enum.Enum):
@@ -82,11 +82,17 @@ class HTTPCycle:
         return await self.app_queue.get()  # pragma: no cover
 
     async def send(self, message: Message) -> None:
-        if self.state is HTTPCycleState.REQUEST and message["type"] == "http.response.start":
+        if (
+            self.state is HTTPCycleState.REQUEST
+            and message["type"] == "http.response.start"
+        ):
             self.status = message["status"]
             self.headers = message.get("headers", [])
             self.state = HTTPCycleState.RESPONSE
-        elif self.state is HTTPCycleState.RESPONSE and message["type"] == "http.response.body":
+        elif (
+            self.state is HTTPCycleState.RESPONSE
+            and message["type"] == "http.response.body"
+        ):
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
             self.buffer.write(body)

--- a/mangum/protocols/http.py
+++ b/mangum/protocols/http.py
@@ -3,8 +3,8 @@ import enum
 import logging
 from io import BytesIO
 
+from mangum.types import ASGI, Message, Scope, Response
 from mangum.exceptions import UnexpectedMessage
-from mangum.types import ASGI, Message, Response, Scope
 
 
 class HTTPCycleState(enum.Enum):
@@ -82,17 +82,11 @@ class HTTPCycle:
         return await self.app_queue.get()  # pragma: no cover
 
     async def send(self, message: Message) -> None:
-        if (
-            self.state is HTTPCycleState.REQUEST
-            and message["type"] == "http.response.start"
-        ):
+        if self.state is HTTPCycleState.REQUEST and message["type"] == "http.response.start":
             self.status = message["status"]
             self.headers = message.get("headers", [])
             self.state = HTTPCycleState.RESPONSE
-        elif (
-            self.state is HTTPCycleState.RESPONSE
-            and message["type"] == "http.response.body"
-        ):
+        elif self.state is HTTPCycleState.RESPONSE and message["type"] == "http.response.body":
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
             self.buffer.write(body)

--- a/mangum/protocols/lifespan.py
+++ b/mangum/protocols/lifespan.py
@@ -4,8 +4,8 @@ import logging
 from types import TracebackType
 from typing import Any, Dict, Optional, Type
 
-from mangum.exceptions import LifespanFailure, LifespanUnsupported, UnexpectedMessage
 from mangum.types import ASGI, LifespanMode, Message
+from mangum.exceptions import LifespanUnsupported, LifespanFailure, UnexpectedMessage
 
 
 class LifespanCycleState(enum.Enum):

--- a/mangum/protocols/lifespan.py
+++ b/mangum/protocols/lifespan.py
@@ -2,10 +2,10 @@ import asyncio
 import enum
 import logging
 from types import TracebackType
-from typing import Optional, Type, Any
+from typing import Any, Dict, Optional, Type
 
+from mangum.exceptions import LifespanFailure, LifespanUnsupported, UnexpectedMessage
 from mangum.types import ASGI, LifespanMode, Message
-from mangum.exceptions import LifespanUnsupported, LifespanFailure, UnexpectedMessage
 
 
 class LifespanCycleState(enum.Enum):
@@ -62,7 +62,7 @@ class LifespanCycle:
         self.startup_event: asyncio.Event = asyncio.Event()
         self.shutdown_event: asyncio.Event = asyncio.Event()
         self.logger = logging.getLogger("mangum.lifespan")
-        self.lifespan_state: dict[str, Any] = {}
+        self.lifespan_state: Dict[str, Any] = {}
 
     def __enter__(self) -> None:
         """Runs the event loop for application startup."""

--- a/mangum/protocols/lifespan.py
+++ b/mangum/protocols/lifespan.py
@@ -2,7 +2,7 @@ import asyncio
 import enum
 import logging
 from types import TracebackType
-from typing import Optional, Type
+from typing import Optional, Type, Any
 
 from mangum.types import ASGI, LifespanMode, Message
 from mangum.exceptions import LifespanUnsupported, LifespanFailure, UnexpectedMessage
@@ -62,6 +62,7 @@ class LifespanCycle:
         self.startup_event: asyncio.Event = asyncio.Event()
         self.shutdown_event: asyncio.Event = asyncio.Event()
         self.logger = logging.getLogger("mangum.lifespan")
+        self.lifespan_state: dict[str, Any] = {}
 
     def __enter__(self) -> None:
         """Runs the event loop for application startup."""
@@ -81,7 +82,7 @@ class LifespanCycle:
         """Calls the application with the `lifespan` connection scope."""
         try:
             await self.app(
-                {"type": "lifespan", "asgi": {"spec_version": "2.0", "version": "3.0"}},
+                {"type": "lifespan", "asgi": {"spec_version": "2.0", "version": "3.0"}, "state": self.lifespan_state},
                 self.receive,
                 self.send,
             )

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,12 +1,14 @@
 import logging
 
 import pytest
-from quart import Quart
+
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 
 from mangum import Mangum
 from mangum.exceptions import LifespanFailure
+
+from quart import Quart
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #323 

The lifespan state is created in lifespan cycle, and a shallow copy is passed in http cycle.
Also added test to confirm the functionality.

Note that a sub-dependency `Hypercorn` need to be pinned to support testing on python 3.7.