### PR TITLE
A basic handler for local lambda invocation or invocations via the aws-sdk

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -6,13 +6,13 @@ from itertools import chain
 from typing import Any
 
 from mangum.exceptions import ConfigurationError
-from mangum.handlers import ALB, APIGateway, HTTPGateway, LambdaAtEdge
+from mangum.handlers import ALB, APIGateway, BasicHandler, HTTPGateway, LambdaAtEdge
 from mangum.protocols import HTTPCycle, LifespanCycle
 from mangum.types import ASGI, LambdaConfig, LambdaContext, LambdaEvent, LambdaHandler, LifespanMode
 
 logger = logging.getLogger("mangum")
 
-HANDLERS: list[type[LambdaHandler]] = [ALB, HTTPGateway, APIGateway, LambdaAtEdge]
+HANDLERS: list[type[LambdaHandler]] = [ALB, HTTPGateway, APIGateway, LambdaAtEdge, BasicHandler]
 
 DEFAULT_TEXT_MIME_TYPES: list[str] = [
     "text/",

--- a/mangum/handlers/__init__.py
+++ b/mangum/handlers/__init__.py
@@ -1,5 +1,6 @@
 from mangum.handlers.alb import ALB
 from mangum.handlers.api_gateway import APIGateway, HTTPGateway
+from mangum.handlers.basic import BasicHandler
 from mangum.handlers.lambda_at_edge import LambdaAtEdge
 
-__all__ = ["APIGateway", "HTTPGateway", "ALB", "LambdaAtEdge"]
+__all__ = ["APIGateway", "HTTPGateway", "ALB", "LambdaAtEdge", "BasicHandler"]

--- a/mangum/handlers/basic.py
+++ b/mangum/handlers/basic.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from mangum.handlers.utils import (
+    handle_exclude_headers,
+    handle_multi_value_headers,
+    maybe_encode_body,
+)
+from mangum.types import (
+    LambdaConfig,
+    LambdaContext,
+    LambdaEvent,
+    Response,
+    Scope,
+)
+
+
+class BaseModelWithForbidExtra(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    @classmethod
+    def is_valid(cls, obj):
+        try:
+            cls.model_validate(obj)
+            return True
+        except ValidationError:
+            return False
+
+
+class MethodEnum(str, Enum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+    PATCH = "PATCH"
+    HEAD = "HEAD"
+    OPTIONS = "OPTIONS"
+    TRACE = "TRACE"
+    CONNECT = "CONNECT"
+
+
+class BasicHandlerEventScope(BaseModelWithForbidExtra):
+    path: str
+    headers: dict[str, str]
+    method: MethodEnum
+
+
+class BasicHandlerEvent(BaseModelWithForbidExtra):
+    scope: BasicHandlerEventScope
+    body: str
+
+
+class BasicHandler:
+    @classmethod
+    def infer(cls, event: LambdaEvent, context: LambdaContext, config: LambdaConfig) -> bool:
+        return BasicHandlerEvent.is_valid(event)
+
+    def __init__(self, event: LambdaEvent, context: LambdaContext, config: LambdaConfig) -> None:
+        self.event = event
+        self.context = context
+        self.config = config
+
+    @property
+    def body(self) -> bytes:
+        return maybe_encode_body(
+            self.event.get("body", b""),
+            is_base64=False,
+        )
+
+    @property
+    def scope(self) -> Scope:
+        headers = self.event.get("headers", {}) or {}
+        headers = {k.lower(): v for k, v in headers.items()}
+
+        return {
+            "path": self.event["scope"]["path"],
+            "method": self.event["scope"]["method"],
+            "headers": [[k.encode(), v.encode()] for k, v in headers.items()],
+            "asgi": {"version": "3.0", "spec_version": "2.0"},
+            "aws.event": self.event,
+            "aws.context": self.context,
+        }
+
+    def __call__(self, response: Response) -> dict[str, Any]:
+        finalized_headers, _ = handle_multi_value_headers(response["headers"])
+
+        return {
+            "statusCode": response["status"],
+            "headers": handle_exclude_headers(finalized_headers, self.config),
+            "body": response["body"],
+        }

--- a/mangum/handlers/basic.py
+++ b/mangum/handlers/basic.py
@@ -79,9 +79,11 @@ class BasicHandler:
         headers = {k.lower(): v for k, v in headers.items()}
 
         return {
+            "type": "http",
             "path": self.event["scope"]["path"],
             "method": self.event["scope"]["method"],
             "headers": [[k.encode(), v.encode()] for k, v in headers.items()],
+            "query_string": b"",
             "asgi": {"version": "3.0", "spec_version": "2.0"},
             "aws.event": self.event,
             "aws.context": self.context,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev-dependencies = [
     "mkautodoc",
     "mkdocs>=1.6.0; python_version >= '3.12'",
     "mkdocs-material; python_version >= '3.12'",
-    "pydantic"
+    "pydantic==2.5.3"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev-dependencies = [
     "mkautodoc",
     "mkdocs>=1.6.0; python_version >= '3.12'",
     "mkdocs-material; python_version >= '3.12'",
+    "pydantic"
 ]
 
 [project.urls]

--- a/tests/handlers/test_basic.py
+++ b/tests/handlers/test_basic.py
@@ -17,9 +17,11 @@ def test_basic_event_scope_real(method, path, body):
     handler = BasicHandler(event, example_context, {})
 
     assert handler.scope == {
+        "type": "http",
         "path": path,
         "method": method,
         "headers": [],
+        "query_string": b"",
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "aws.context": {},
         "aws.event": event,

--- a/tests/handlers/test_basic.py
+++ b/tests/handlers/test_basic.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+
+from mangum import Mangum
+from mangum.handlers import BasicHandler
+
+
+def get_valid_mock_aws_basic_event(method, path, body, headers):
+    return {"scope": {"method": method, "path": path, "headers": headers}, "body": body}
+
+
+@pytest.mark.parametrize("method,path,body", [("GET", "/", "")])
+def test_basic_event_scope_real(method, path, body):
+    event = get_valid_mock_aws_basic_event(method, path, body, {})
+    example_context = {}
+    handler = BasicHandler(event, example_context, {})
+
+    assert handler.scope == {
+        "path": path,
+        "method": method,
+        "headers": [],
+        "asgi": {"version": "3.0", "spec_version": "2.0"},
+        "aws.context": {},
+        "aws.event": event,
+    }
+
+
+@pytest.mark.parametrize(
+    "model, is_valid",
+    [
+        ({}, False),
+        ({"scope": {"path": "/", "method": "POST", "headers": {}}, "body": ""}, True),
+        ({"scope": {"path": "/", "method": "POST", "headers": {}}}, False),
+        ({"scope": {"path": "/", "method": "POST", "headers": {}}, "body": "", "extra": ""}, False),
+        ({"scope": {"path": "/", "method": "UNKNOWN", "headers": {}}, "body": ""}, False),
+    ],
+)
+def test_basic_event_infer(model, is_valid):
+    example_context = {}
+    assert BasicHandler.infer(model, example_context, {}) == is_valid
+
+
+@pytest.mark.parametrize(
+    "method,path,request_content_type,response_content_type,payload,response",
+    [
+        ("GET", "/", b"text/plain; charset=utf-8", b"text/plain; charset=utf-8", b"Hello world", b"Hello world"),
+        (
+            "GET",
+            "/",
+            b"application/json",
+            b"text/plain; charset=utf-8",
+            json.dumps({"hello": "world"}).encode("utf-8"),
+            b"Hello world",
+        ),
+    ],
+)
+def test_aws_api_gateway_response(method, path, request_content_type, response_content_type, payload, response):
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", response_content_type]],
+            }
+        )
+        await send({"type": "http.response.body", "body": response})
+
+    event = get_valid_mock_aws_basic_event(method, path, payload, {"Content-Type": request_content_type})
+
+    handler = Mangum(app, lifespan="off")
+
+    result = handler(event, {})
+
+    assert result == {
+        "statusCode": 200,
+        "headers": {"content-type": response_content_type.decode()},
+        "body": response,
+    }

--- a/tests/handlers/test_basic.py
+++ b/tests/handlers/test_basic.py
@@ -30,9 +30,10 @@ def test_basic_event_scope_real(method, path, body):
     "model, is_valid",
     [
         ({}, False),
-        ({"scope": {"path": "/", "method": "POST", "headers": {}}, "body": ""}, True),
+        ({"scope": {"path": "/", "method": "POST", "headers": {}}, "body": b""}, True),
         ({"scope": {"path": "/", "method": "POST", "headers": {}}}, False),
-        ({"scope": {"path": "/", "method": "POST", "headers": {}}, "body": "", "extra": ""}, False),
+        ({"scope": {"path": "/", "method": "POST", "headers": {}}, "body": b"", "extra": ""}, False),
+        ({"scope": {"path": "/", "method": "UNKNOWN", "headers": {}}, "body": b""}, False),
         ({"scope": {"path": "/", "method": "UNKNOWN", "headers": {}}, "body": ""}, False),
     ],
 )
@@ -51,6 +52,14 @@ def test_basic_event_infer(model, is_valid):
             b"application/json",
             b"text/plain; charset=utf-8",
             json.dumps({"hello": "world"}).encode("utf-8"),
+            b"Hello world",
+        ),
+        (
+            "GET",
+            "/",
+            b"text/plain; charset=utf-8",
+            b"text/plain; charset=utf-8",
+            b"",
             b"Hello world",
         ),
     ],


### PR DESCRIPTION
If a lambda is not provisioned behind an api gateway, load balancer or edge, then the caller of the lambda function has to format its request payload to 'pretend' to be one of these formats to 'match' a handler.

An example of this occurs when invoking a lambda function from within the aws network using the aws sdk.

For fun, I create a very basic handler that carries out no manipulations on the body and has strict schema matching for simplicity of payload generation.