### PR TITLE
Fix DeprecationWarning during Mangum construction on Python 3.12+

### DIFF
--- a/mangum/adapter.py
+++ b/mangum/adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import warnings
 from contextlib import ExitStack
 from itertools import chain
 from typing import Any
@@ -62,7 +63,9 @@ class Mangum:
 
     def _setup_event_loop(self) -> None:
         try:
-            asyncio.get_event_loop()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                asyncio.get_event_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ filterwarnings = [
     # Turn warnings that aren't filtered into exceptions
     "error",
     "ignore::DeprecationWarning:starlette",
-    "ignore: There is no current event loop:DeprecationWarning",
     "ignore: 'pkgutil.get_loader' is deprecated.*:DeprecationWarning",
     "ignore: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead:DeprecationWarning",
     "ignore: Attribute s is deprecated and will be removed in Python 3.14; use value instead:DeprecationWarning",


### PR DESCRIPTION
## Summary

Closes #377.

Since 0.21.0, `Mangum(app)` emits `DeprecationWarning: There is no current event loop` on Python 3.12 and 3.13. Downstream projects running pytest with `filterwarnings = ["error"]` (or `-W error`) fail at collection time as soon as `Mangum(app)` runs at module top level.

Root cause: `_setup_event_loop` (added in #375) probes for an existing thread-set loop with `asyncio.get_event_loop()`. On 3.12/3.13, when no loop is set, that call **emits the deprecation warning and silently auto-creates a loop** rather than raising — so the existing `except RuntimeError` fallback never executes, and the probe leaks the warning to every caller of `Mangum.__init__`.

## Fix

Wrap the probe in `warnings.catch_warnings()` to suppress the (non-actionable) `DeprecationWarning`, while keeping the same control flow:

```python
def _setup_event_loop(self) -> None:
    try:
        with warnings.catch_warnings():
            warnings.simplefilter("ignore", DeprecationWarning)
            asyncio.get_event_loop()
    except RuntimeError:
        loop = asyncio.new_event_loop()
        asyncio.set_event_loop(loop)
```

The deprecation message ("auto-create branch is going away in 3.14") is informational — `_setup_event_loop` already handles the post-3.14 world via the `except RuntimeError` arm, which is exercised on 3.14 where `get_event_loop()` raises instead of warning.

The redundant `"ignore: There is no current event loop"` entry is removed from `pyproject.toml`'s `filterwarnings` since the source no longer emits the warning.

## Why not `asyncio.get_running_loop()`?

The first version of this patch swapped the probe to `asyncio.get_running_loop()`, which raises cleanly without warning when nothing is running. That looked tidier but **regressed behavior**: `get_running_loop()` only sees *currently-executing* loops, not loops previously installed via `set_event_loop()`. So on every subsequent `Mangum(...)` construction in the same process, it would fall through to `new_event_loop()` + `set_event_loop()`, **orphaning the previously-installed loop without closing it**.

This surfaced as `ResourceWarning: unclosed event loop` in mangum's own test suite — 7 failures and 2 errors out of 103 tests on 3.12 — because tests construct `Mangum(...)` repeatedly. It would also affect dev hot-reload and any non-Lambda consumer that constructs the adapter more than once. Lambda's typical lifecycle (one construction per cold start) would mask it, but the library shouldn't expose the footgun.

`get_event_loop()` returns the existing thread-set loop without re-creating one, so suppression is the smaller, more correct fix.

## Verification

- **`pyproject.toml` filter (mangum's own tests):** Without the source-level fix, the filter masks the warning only for mangum's CI; downstream projects don't inherit pytest config from installed dependencies. Verified by installing the built wheel into a fresh project with `filterwarnings = ["error"]`:

  | Installed mangum | Result |
  |---|---|
  | This branch's wheel | 2 passed |
  | `mangum==0.21.0` (PyPI) | Collection error — `DeprecationWarning: There is no current event loop` at `adapter.py:65` |

- **Existing test suite (Python 3.12):** 103 passed with the `pyproject.toml` filter removed, confirming the warning is no longer emitted at the source.

- **Python 3.14 forward-compat preserved:** Verified end-to-end on 3.14 — init and a request both produce zero warnings, response status 200. The `except RuntimeError` arm still creates and installs a loop when `get_event_loop()` raises.

## Test plan

- [x] `mangum==0.21.0` (unfixed) reproducer fails at pytest collection on Python 3.12
- [x] Branch wheel passes the same downstream reproducer
- [x] Existing test suite passes on Python 3.12 with the now-redundant filter removed
- [x] Smoke test on Python 3.14 — no warnings, request returns 200