### PR TITLE
Remove dead external docs link

### DIFF
--- a/docs/external-links.md
+++ b/docs/external-links.md
@@ -3,6 +3,5 @@
 External links related to using Mangum.
 
 - [Deploying Python web apps as AWS Lambda functions](https://til.simonwillison.net/awslambda/asgi-mangum) is a tutorial that goes through every step involved in packaging and deploying a Python web application to AWS Lambda, including how to use Mangum to wrap an ASGI application.
-- [Deploy FastAPI applications to AWS Lambda](https://aminalaee.dev/posts/2022/fastapi-aws-lambda/) is a quick tutorial about how to deploy FastAPI and Starlette applications to AWS Lambda using Mangum, including also a suggested approach by AWS about how to manage larger applications.
 
 If you're interested in contributing to this page, please reference this [issue](https://github.com/jordaneremieff/mangum/issues/104) in a PR.


### PR DESCRIPTION
## Summary

- remove the dead FastAPI/AWS Lambda external article link from the docs
- keep the remaining external link list intact

Refs #104.

## Validation

- `git diff --check`
- `rg -n "aminalaee|fastapi-aws-lambda|Deploy FastAPI applications" docs README.md mkdocs.yml`
- Checked that the remaining external link still responds with HTTP 200
- Not run locally: docs build or test suite
