### PR TITLE
Set root_path from API Gateway base path

### DIFF
--- a/mangum/handlers/api_gateway.py
+++ b/mangum/handlers/api_gateway.py
@@ -4,6 +4,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 from mangum.handlers.utils import (
+    get_api_gateway_root_path,
     get_server_and_port,
     handle_base64_response_body,
     handle_exclude_headers,
@@ -94,7 +95,7 @@ class APIGateway:
                 api_gateway_base_path=self.config["api_gateway_base_path"],
             ),
             "raw_path": None,
-            "root_path": "",
+            "root_path": get_api_gateway_root_path(self.config["api_gateway_base_path"]),
             "scheme": headers.get("x-forwarded-proto", "https"),
             "query_string": _encode_query_string_for_apigw(self.event),
             "server": get_server_and_port(headers),
@@ -177,7 +178,7 @@ class HTTPGateway:
             "headers": [[k.encode(), v.encode()] for k, v in headers.items()],
             "path": path,
             "raw_path": None,
-            "root_path": "",
+            "root_path": get_api_gateway_root_path(self.config["api_gateway_base_path"]),
             "scheme": headers.get("x-forwarded-proto", "https"),
             "query_string": query_string,
             "server": server,

--- a/mangum/handlers/utils.py
+++ b/mangum/handlers/utils.py
@@ -41,6 +41,16 @@ def strip_api_gateway_path(path: str, *, api_gateway_base_path: str) -> str:
     return unquote(path)
 
 
+def get_api_gateway_root_path(api_gateway_base_path: str) -> str:
+    if not api_gateway_base_path or api_gateway_base_path == "/":
+        return ""
+
+    if not api_gateway_base_path.startswith("/"):
+        return f"/{api_gateway_base_path}"
+
+    return api_gateway_base_path
+
+
 def handle_multi_value_headers(
     response_headers: Headers,
 ) -> tuple[dict[str, str], dict[str, list[str]]]:

--- a/tests/handlers/test_api_gateway.py
+++ b/tests/handlers/test_api_gateway.py
@@ -260,6 +260,7 @@ def test_aws_api_gateway_base_path(
     async def app(scope, receive, send):
         assert scope["type"] == "http"
         assert scope["path"] == urllib.parse.unquote(event["path"])
+        assert scope["root_path"] == ""
         await send(
             {
                 "type": "http.response.start",
@@ -283,6 +284,7 @@ def test_aws_api_gateway_base_path(
     async def app(scope, receive, send):
         assert scope["type"] == "http"
         assert scope["path"] == urllib.parse.unquote(event["path"][len(f"/{api_gateway_base_path}") :])
+        assert scope["root_path"] == f"/{api_gateway_base_path}"
         await send(
             {
                 "type": "http.response.start",

--- a/tests/handlers/test_http_gateway.py
+++ b/tests/handlers/test_http_gateway.py
@@ -230,6 +230,14 @@ def test_aws_http_gateway_scope_v1_no_headers():
     assert handler.scope["query_string"] == b""
 
 
+def test_aws_http_gateway_scope_v1_base_path_sets_root_path():
+    event = get_mock_aws_http_gateway_event_v1("GET", "/api/test", {}, None, False)
+    handler = HTTPGateway(event, {}, {"api_gateway_base_path": "api"})
+
+    assert handler.scope["path"] == "/test"
+    assert handler.scope["root_path"] == "/api"
+
+
 def test_aws_http_gateway_scope_basic_v2():
     """
     Test the event from the AWS docs
@@ -307,6 +315,14 @@ def test_aws_http_gateway_scope_basic_v2():
         "server": ("mangum", 80),
         "type": "http",
     }
+
+
+def test_aws_http_gateway_scope_v2_base_path_sets_root_path():
+    event = get_mock_aws_http_gateway_event_v2("GET", "/api/test", {}, None, False)
+    handler = HTTPGateway(event, {}, {"api_gateway_base_path": "api"})
+
+    assert handler.scope["path"] == "/test"
+    assert handler.scope["root_path"] == "/api"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Set API Gateway ASGI scopes' root_path from api_gateway_base_path when a base path is configured.
- Keep root_path empty for the default root deployment.
- Add REST API and HTTP API coverage for stripped path plus root_path behavior.

Fixes #318

## Validation
- Not run locally.