### PR TITLE
Bump starlette to 1.3.1 and require starlette>=1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "pytest>=8.0.0",
     "coverage",
     "ruff",
-    "starlette",
+    "starlette>=1.0",
     "quart>=0.20.0",
     "hypercorn>=0.15.0",
     "mypy",
@@ -76,7 +76,6 @@ xfail_strict = true
 filterwarnings = [
     # Turn warnings that aren't filtered into exceptions
     "error",
-    "ignore::DeprecationWarning:starlette",
     # testcontainers calls its own deprecated wait_for_logs API during container startup
     "ignore: The wait_for_logs function with string or callable predicates is deprecated.*:DeprecationWarning",
     "ignore: There is no current event loop:DeprecationWarning",

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Literal, cast
 
 import pytest
@@ -6,6 +8,7 @@ from quart import Quart
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 
 from mangum import Mangum
 from mangum.exceptions import LifespanFailure
@@ -269,21 +272,18 @@ def test_starlette_lifespan(mock_aws_api_gateway_event: LambdaEvent) -> None:
     shutdown_complete = False
 
     path = mock_aws_api_gateway_event["path"]
-    app = Starlette()
 
-    @app.on_event("startup")
-    async def on_startup() -> None:
-        nonlocal startup_complete
+    @asynccontextmanager
+    async def lifespan(app: Starlette) -> AsyncIterator[None]:
+        nonlocal startup_complete, shutdown_complete
         startup_complete = True
-
-    @app.on_event("shutdown")
-    async def on_shutdown() -> None:
-        nonlocal shutdown_complete
+        yield
         shutdown_complete = True
 
-    @app.route(path)
     def homepage(request: Request) -> PlainTextResponse:
         return PlainTextResponse("Hello, world!")
+
+    app = Starlette(lifespan=lifespan, routes=[Route(path, homepage)])
 
     assert not startup_complete
     assert not shutdown_complete

--- a/uv.lock
+++ b/uv.lock
@@ -1246,15 +1246,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.49.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/3f/507c21db33b66fb027a332f2cb3abbbe924cc3a79ced12f01ed8645955c9/starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb", size = 2654703, upload-time = "2025-10-28T17:34:10.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/da/545b75d420bb23b5d494b0517757b351963e974e79933f01e05c929f20a6/starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875", size = 74175, upload-time = "2025-10-28T17:34:09.13Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -764,7 +764,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "quart", specifier = ">=0.20.0" },
     { name = "ruff" },
-    { name = "starlette" },
+    { name = "starlette", specifier = ">=1.0" },
     { name = "testcontainers", extras = ["localstack"], specifier = ">=4.15.0" },
     { name = "types-boto3", specifier = ">=1.43.78" },
 ]


### PR DESCRIPTION
Supersedes [#397](https://github.com/Kludex/mangum/pull/397), which failed CI because Starlette 1.x removed the deprecated `on_event` and `route` decorators.

- Bump starlette 0.49.1 -> 1.3.1 and pin `starlette>=1.0` in the dev group.
- Rewrite `test_starlette_lifespan` using the `lifespan` context manager and explicit `routes`.
- Drop the now-unneeded `ignore::DeprecationWarning:starlette` filter.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.