### PR TITLE
Allow manual documentation deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "**"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
The docs only deploy on tag pushes, so fixes like [#387](https://github.com/Kludex/mangum/pull/387) and [#389](https://github.com/Kludex/mangum/pull/389) (correcting an external link whose old domain now hosts a casino site, [#390](https://github.com/Kludex/mangum/issues/390)) sit unpublished until the next release. Adding `workflow_dispatch` lets docs be redeployed on demand.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.